### PR TITLE
Allow hosts by dns

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,7 +17,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package cmd
 
 import (
-	"net"
 	"time"
 
 	"github.com/NETWAYS/go-check"
@@ -27,7 +26,7 @@ import (
 // rootCmd represents the base command when called without any subcommands
 var (
 	version  string = "0.1.0"
-	ip       net.IP
+	ip       string 
 	hostname string
 	port     int
 	username string
@@ -58,7 +57,7 @@ func init() {
 	// Cobra supports persistent flags, which, if defined here,
 	// will be global for your application.
 
-	rootCmd.PersistentFlags().IPVarP(&ip, "IP-address", "I", nil, "IP of the Traefik host to check (required)")
+	rootCmd.PersistentFlags().StringVarP(&ip, "IP-address", "I", "", "IP of the Traefik host to check (required)")
 	rootCmd.MarkPersistentFlagRequired("IP-address")
 	rootCmd.PersistentFlags().StringVarP(&hostname, "hostname", "H", "", "Hostname of the Traefik host to check")
 	rootCmd.PersistentFlags().IntVarP(&port, "port", "P", 80, "Port of the Traefik API")

--- a/internal/http.go
+++ b/internal/http.go
@@ -18,7 +18,6 @@ package internal
 
 import (
 	"crypto/tls"
-	"net"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -27,7 +26,7 @@ import (
 	"github.com/NETWAYS/go-check"
 )
 
-func NewRequest(method string, ip net.IP, hostname string, ssl bool, port int, path string, username string, password string) *http.Request {
+func NewRequest(method string, ip string, hostname string, ssl bool, port int, path string, username string, password string) *http.Request {
 	var (
 		hostPort  string = ""
 		schema    string = "http"
@@ -47,7 +46,7 @@ func NewRequest(method string, ip net.IP, hostname string, ssl bool, port int, p
 	}
 	healthUrl = &url.URL{
 		Scheme: schema,
-		Host:   ip.String() + hostPort,
+		Host:   ip + hostPort,
 		Path:   path,
 	}
 


### PR DESCRIPTION
For my project I need to be able to use dns to get the IP address. To achieve this I changed the net.IP to a string, so I can use the DNS Names and send my requests without knowing the ip. Also there is no place where it is important to have the net.IP object, only for input validation.

So it's your dicision if you want that pull request or not. Just opening in case anyone needs it.